### PR TITLE
default `channelCountMode` for `AudioDestinationNode`

### DIFF
--- a/lib/AudioDestinationNode.js
+++ b/lib/AudioDestinationNode.js
@@ -5,6 +5,7 @@ var _ = require('underscore')
 
 var AudioDestinationNode = module.exports = function(context) {
   AudioNode.call(this, context, 1, 0)
+  this.channelCountMode = 'explicit'
   readOnlyAttr(this, 'channelCount', 2)
   readOnlyAttr(this, 'channelInterpretation', 'speakers')
   readOnlyAttr(this, 'channelInterpretation', 'discrete')  


### PR DESCRIPTION
Thanks for this great library! With the recent changes, looks like a default was overlooked. Without an explicit `channelCountMode`, audioports would throw every time, preventing even the manual testing from succeeding.
