### PR TITLE
Fixes runtime-error and performance issue

### DIFF
--- a/lib/AudioContext.js
+++ b/lib/AudioContext.js
@@ -19,7 +19,7 @@ try {
   console.warn('Speaker is not available, fix this if you need sound playback.')
 }
 
-var AudioContext = module.exports = function() {
+var AudioContext = module.exports = function(opts) {
   var self = this
     , outBuff
 
@@ -51,6 +51,10 @@ var AudioContext = module.exports = function() {
     bitDepth: 16,         // 16-bit samples
     sampleRate: 44100     // 44,100 Hz sample rate
   }
+  
+  opts = opts || {};
+  if (opts.bufferSize) format.bufferSize = opts.bufferSize;
+  if (opts.numBuffers) format.numBuffers = opts.numBuffers;
 
   if (Speaker) this.outStream = new Speaker(format)
   else this.outStream = null


### PR DESCRIPTION
Unless I'm missing something, AudioBuffer.zeros doesn't exist, but "new
AudioBuffer" works perfectly with the same arguments, so I've refactored
"createBuffer" to use the constructor directly.

Also, connecting to AudioContext.destination multiple times would result
in the audio loop running multiple times in parallel, causing increasing
performance degradation as multiple sounds were played.

I've added guard clauses around the audio-loop so that this issue no
longer occurs.
