### PR TITLE
Use automation-events to process AudioParam automations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "aac": "0.1.x",
         "alac": "0.1.x",
+        "automation-events": "^4.0.14",
         "av": "0.4.x",
         "flac": "0.3.x",
         "mp3": "0.1.x"
@@ -22,6 +23,17 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.17.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.2.tgz",
+      "integrity": "sha512-hzeyJyMA1YGdJTuWU0e/j4wKXrU4OMFvY2MSlaI9B7VQb0r5cxTE3EAIS2Q7Tn2RIcDkRvTA/v2JsAEhxe99uw==",
+      "dependencies": {
+        "regenerator-runtime": "^0.13.4"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@ungap/promise-all-settled": {
@@ -63,6 +75,30 @@
         "node": ">=6"
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/anymatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
@@ -89,6 +125,18 @@
       "dev": true,
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/automation-events": {
+      "version": "4.0.14",
+      "resolved": "https://registry.npmjs.org/automation-events/-/automation-events-4.0.14.tgz",
+      "integrity": "sha512-CB2Me0yW8sz7gSGwMiSfgfs1Oqlgs53k+eVESN6axvRyMAD3zlSp2nqndD2TQAtW3yOtSEJWNGsw0r48+f1wtw==",
+      "dependencies": {
+        "@babel/runtime": "^7.17.2",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=12.20.1"
       }
     },
     "node_modules/av": {
@@ -232,18 +280,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/chokidar/node_modules/is-glob": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
-      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "dev": true,
-      "dependencies": {
-        "is-extglob": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/chokidar/node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -274,27 +310,6 @@
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
         "wrap-ansi": "^7.0.0"
-      }
-    },
-    "node_modules/cliui/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/cliui/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/coffee-script": {
@@ -536,18 +551,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/glob-parent/node_modules/is-glob": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
-      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "dev": true,
-      "dependencies": {
-        "is-extglob": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/growl": {
       "version": "1.10.5",
       "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
@@ -621,6 +624,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-plain-obj": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
@@ -689,21 +704,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/log-symbols/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/log-symbols/node_modules/chalk": {
@@ -844,21 +844,6 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true
-    },
-    "node_modules/mocha/node_modules/supports-color": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/supports-color?sponsor=1"
-      }
     },
     "node_modules/mp3": {
       "version": "0.1.0",
@@ -1006,6 +991,11 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/regenerator-runtime": {
+      "version": "0.13.9",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
+      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -1016,24 +1006,10 @@
       }
     },
     "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ]
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "devOptional": true
     },
     "node_modules/serialize-javascript": {
       "version": "6.0.0",
@@ -1078,12 +1054,6 @@
         "util-deprecate": "~1.0.1"
       }
     },
-    "node_modules/speaker/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "optional": true
-    },
     "node_modules/speaker/node_modules/string_decoder": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
@@ -1107,16 +1077,7 @@
         "node": ">=8"
       }
     },
-    "node_modules/string-width/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/string-width/node_modules/strip-ansi": {
+    "node_modules/strip-ansi": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
@@ -1140,10 +1101,30 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
     "node_modules/through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+    },
+    "node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
     },
     "node_modules/type-detect": {
       "version": "4.0.8",
@@ -1202,42 +1183,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/wrap-ansi/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/wrap-ansi/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/wrap-ansi/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/wrappy": {
@@ -1311,6 +1256,14 @@
     }
   },
   "dependencies": {
+    "@babel/runtime": {
+      "version": "7.17.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.2.tgz",
+      "integrity": "sha512-hzeyJyMA1YGdJTuWU0e/j4wKXrU4OMFvY2MSlaI9B7VQb0r5cxTE3EAIS2Q7Tn2RIcDkRvTA/v2JsAEhxe99uw==",
+      "requires": {
+        "regenerator-runtime": "^0.13.4"
+      }
+    },
     "@ungap/promise-all-settled": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
@@ -1340,6 +1293,21 @@
       "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
       "dev": true
     },
+    "ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true
+    },
+    "ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "requires": {
+        "color-convert": "^2.0.1"
+      }
+    },
     "anymatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
@@ -1361,6 +1329,15 @@
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
       "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
       "dev": true
+    },
+    "automation-events": {
+      "version": "4.0.14",
+      "resolved": "https://registry.npmjs.org/automation-events/-/automation-events-4.0.14.tgz",
+      "integrity": "sha512-CB2Me0yW8sz7gSGwMiSfgfs1Oqlgs53k+eVESN6axvRyMAD3zlSp2nqndD2TQAtW3yOtSEJWNGsw0r48+f1wtw==",
+      "requires": {
+        "@babel/runtime": "^7.17.2",
+        "tslib": "^2.3.1"
+      }
     },
     "av": {
       "version": "0.4.9",
@@ -1469,15 +1446,6 @@
             "to-regex-range": "^5.0.1"
           }
         },
-        "is-glob": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
-          "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-          "dev": true,
-          "requires": {
-            "is-extglob": "^2.1.1"
-          }
-        },
         "is-number": {
           "version": "7.0.0",
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -1504,23 +1472,6 @@
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
         "wrap-ansi": "^7.0.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-          "dev": true
-        },
-        "strip-ansi": {
-          "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^5.0.1"
-          }
-        }
       }
     },
     "coffee-script": {
@@ -1697,17 +1648,6 @@
       "dev": true,
       "requires": {
         "is-glob": "^4.0.1"
-      },
-      "dependencies": {
-        "is-glob": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
-          "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-          "dev": true,
-          "requires": {
-            "is-extglob": "^2.1.1"
-          }
-        }
       }
     },
     "growl": {
@@ -1765,6 +1705,15 @@
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
       "dev": true
     },
+    "is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "requires": {
+        "is-extglob": "^2.1.1"
+      }
+    },
     "is-plain-obj": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
@@ -1811,15 +1760,6 @@
         "is-unicode-supported": "^0.1.0"
       },
       "dependencies": {
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
         "chalk": {
           "version": "4.1.2",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -1924,15 +1864,6 @@
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
           "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
           "dev": true
-        },
-        "supports-color": {
-          "version": "8.1.1",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-          "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
         }
       }
     },
@@ -2041,6 +1972,11 @@
         "picomatch": "^2.2.1"
       }
     },
+    "regenerator-runtime": {
+      "version": "0.13.9",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
+      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
+    },
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -2048,10 +1984,10 @@
       "dev": true
     },
     "safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "devOptional": true
     },
     "serialize-javascript": {
       "version": "6.0.0",
@@ -2095,12 +2031,6 @@
             "util-deprecate": "~1.0.1"
           }
         },
-        "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "optional": true
-        },
         "string_decoder": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
@@ -2121,23 +2051,15 @@
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
         "strip-ansi": "^6.0.1"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-          "dev": true
-        },
-        "strip-ansi": {
-          "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^5.0.1"
-          }
-        }
+      }
+    },
+    "strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^5.0.1"
       }
     },
     "strip-json-comments": {
@@ -2146,10 +2068,24 @@
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
       "dev": true
     },
+    "supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "requires": {
+        "has-flag": "^4.0.0"
+      }
+    },
     "through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+    },
+    "tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
     },
     "type-detect": {
       "version": "4.0.8",
@@ -2193,32 +2129,6 @@
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
         "strip-ansi": "^6.0.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-          "dev": true
-        },
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "strip-ansi": {
-          "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^5.0.1"
-          }
-        }
       }
     },
     "wrappy": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "aac": "0.1.x",
     "alac": "0.1.x",
+    "automation-events": "^4.0.14",
     "av": "0.4.x",
     "flac": "0.3.x",
     "mp3": "0.1.x"

--- a/src/AudioParam.js
+++ b/src/AudioParam.js
@@ -2,6 +2,7 @@ import DspObject from './DspObject.js'
 import { AudioInput } from './audioports.js'
 import AudioBuffer from './AudioBuffer.js'
 import { BLOCK_SIZE } from './constants.js'
+import { AutomationEventList, createExponentialRampToValueAutomationEvent, createLinearRampToValueAutomationEvent, createSetTargetAutomationEvent, createSetValueAutomationEvent, createSetValueCurveAutomationEvent } from 'automation-events';
 
 class AudioParam extends DspObject {
 
@@ -28,13 +29,11 @@ class AudioParam extends DspObject {
       },
       set: function(newVal) {
         this._instrinsicValue = newVal
-        this._toConstant()
-        this._scheduled = []
+        this._automationEventList.add(createSetValueAutomationEvent(newVal, this.context.currentTime))
       }
     })
 
-    this._toConstant()
-
+    this._automationEventList = new AutomationEventList(defaultValue)
     // Using AudioNodes as inputs for AudioParam :
     // we have to set same channel attributes as for AudioNodes,
     // so the input knows how to do the mixing
@@ -45,57 +44,25 @@ class AudioParam extends DspObject {
   }
 
   setValueAtTime(value, startTime) {
-    this._schedule('SetValue', startTime, () => {
-      this._instrinsicValue = value
-      this._nextEvent()
-    })
+    this._automationEventList.add(createSetValueAutomationEvent(value, startTime))
   }
 
   linearRampToValueAtTime(value, endTime) {
-    this._schedule('LinearRampToValue', endTime, () => {
-      this._instrinsicValue = value
-      this._nextEvent()
-    }, [value])
-    this._nextEvent()
+    this._automationEventList.add(createLinearRampToValueAutomationEvent(value, endTime))
   }
 
   exponentialRampToValueAtTime(value, endTime) {
     if (this._instrinsicValue <= 0 || value <= 0)
       throw new Error('cannot create exponential ramp with value <= 0')
-    this._schedule('ExponentialRampToValue', endTime, () => {
-      this._instrinsicValue = value
-      this._nextEvent()
-    }, [value])
-    this._nextEvent()
+    this._automationEventList.add(createExponentialRampToValueAutomationEvent(value, endTime))
   }
 
   setTargetAtTime(target, startTime, timeConstant) {
-    this._schedule('SetTarget', startTime, () => {
-      this['_to_' + this._rate + 'Rate_setTarget'](target, timeConstant, () => {
-        this._instrinsicValue = target
-        this._nextEvent()
-      })
-    })
+    this._automationEventList.add(createSetTargetAutomationEvent(target, startTime, timeConstant))
   }
 
   setValueCurveAtTime(values, startTime, duration) {
-    this._schedule('SetValueCurve', startTime, () => {
-      this['_to_' + this._rate + 'Rate_SetValueCurve'](values, startTime, duration, () => {
-        this._instrinsicValue = values[values.length - 1]
-        this._nextEvent()
-      })
-    })
-  }
-
-  _nextEvent() {
-    var event = this._scheduled[0]
-    if (event) {
-      if (event.type === 'LinearRampToValue')
-        this['_to_' + this._rate + 'Rate_linearRamp'](event.args[0], event.time)
-      else if (event.type === 'ExponentialRampToValue')
-        this['_to_' + this._rate + 'Rate_exponentialRamp'](event.args[0], event.time)
-      else this._toConstant()
-    } else this._toConstant()
+    this._automationEventList.add(createSetValueCurveAutomationEvent(values, startTime, duration))
   }
 
   _tick() {
@@ -106,160 +73,21 @@ class AudioParam extends DspObject {
   }
 
   // This method calculates intrinsic values
-  _dsp() {}
+  _dsp(array) {
+    var i
 
-  // -------------------- DSP methods -------------------- //
-  _toConstant() {
-    var value = this._instrinsicValue,
-      i
-
-    this._dsp = function(array) {
-      for (i = 0; i < BLOCK_SIZE; i++) array[i] = value
-    }
-  }
-
-  _to_aRate_linearRamp(target, endTime) {
-    var U0 = this._instrinsicValue,
-      Un = U0,
-      startTime = this.context.currentTime,
-      step = (target - U0) / (endTime - startTime) * 1 / this.context.sampleRate,
-      next = this._arithmeticSeries(U0, step),
-      clip = step > 0 ? Math.min : Math.max,
-      i
-
-    this._dsp = function(array) {
+    if (this._rate === 'a') {
       for (i = 0; i < BLOCK_SIZE; i++) {
-        array[i] = clip(Un, target)
-        Un = next()
+        array[i] = this._automationEventList.getValue(this.context.currentTime + i / this.context.sampleRate)
       }
-      this._instrinsicValue = array[BLOCK_SIZE - 1]
-    }
-  }
+    } else {
+      var value = this._automationEventList.getValue(this.context.currentTime)
 
-  _to_kRate_linearRamp(target, endTime) {
-    var U0 = this._instrinsicValue,
-      Un = U0,
-      startTime = this.context.currentTime,
-      step = (target - U0) / (endTime - startTime) * BLOCK_SIZE / this.context.sampleRate,
-      next = this._arithmeticSeries(U0, step),
-      i
-
-    this._dsp = function(array) {
-      for (i = 0; i < BLOCK_SIZE; i++) array[i] = Un
-      Un = next()
-      this._instrinsicValue = array[BLOCK_SIZE - 1]
-    }
-  }
-
-  _to_aRate_exponentialRamp(target, timeEnd) {
-    var timeStart = this.context.currentTime,
-      U0 = this._instrinsicValue,
-      Un = U0,
-      ratio = Math.pow(target / U0, 1 / (this.context.sampleRate * (timeEnd - timeStart))),
-      next = this._geometricSeries(U0, ratio),
-      clip = ratio > 1 ? Math.min : Math.max,
-      i
-
-    this._dsp = function(array) {
       for (i = 0; i < BLOCK_SIZE; i++) {
-        array[i] = clip(target, Un)
-        Un = next()
+        array[i] = value
       }
-      this._instrinsicValue = array[BLOCK_SIZE - 1]
     }
-  }
-
-  _to_kRate_exponentialRamp(target, timeEnd) {
-    var timeStart = this.context.currentTime,
-      U0 = this._instrinsicValue,
-      Un = U0,
-      ratio = Math.pow(target / U0, BLOCK_SIZE / (this.context.sampleRate * (timeEnd - timeStart))),
-      next = this._geometricSeries(U0, ratio),
-      i
-
-    this._dsp = function(array) {
-      for (i = 0; i < BLOCK_SIZE; i++) array[i] = Un
-      Un = next()
-      this._instrinsicValue = array[BLOCK_SIZE - 1]
-    }
-  }
-
-  _to_aRate_setTarget(target, Tc, onended) {
-    var timeStart = this.context.currentTime,
-      U0 = (this._instrinsicValue - target),
-      Un = target + U0,
-      ratio = Math.exp(-(1 / this.context.sampleRate) / Tc),
-      next = this._geometricSeries(U0, ratio),
-      clip = U0 > 0 ? Math.max : Math.min,
-      i
-
-    this._dsp = function(array) {
-      for (i = 0; i < BLOCK_SIZE; i++) {
-        array[i] = clip(Un, target)
-        Un = target + next()
-      }
-      this._instrinsicValue = array[BLOCK_SIZE - 1]
-      if (array[BLOCK_SIZE - 1] === target) onended()
-    }
-  }
-
-  _to_kRate_setTarget(target, Tc, onended) {
-    var timeStart = this.context.currentTime,
-      U0 = this._instrinsicValue - target,
-      Un = target + U0,
-      ratio = Math.exp(-(BLOCK_SIZE / this.context.sampleRate) / Tc),
-      next = this._geometricSeries(U0, ratio),
-      i
-
-    this._dsp = function(array) {
-      for (i = 0; i < BLOCK_SIZE; i++) array[i] = Un
-      Un = target + next()
-      this._instrinsicValue = array[BLOCK_SIZE - 1]
-    }
-  }
-
-  _to_aRate_SetValueCurve(values, startTime, duration, onended) {
-    var valuesLength = values.length,
-      coeff = valuesLength / duration,
-      Ts = 1 / this.context.sampleRate,
-      i, t
-
-    this._dsp = function(array) {
-      t = this.context.currentTime
-      for (i = 0; i < BLOCK_SIZE; i++) {
-        array[i] = values[Math.min(Math.round(coeff * (t - startTime)), valuesLength - 1)]
-        t += Ts
-      }
-      this._instrinsicValue = array[BLOCK_SIZE - 1]
-      if (t - startTime >= duration) onended()
-    }
-  }
-
-  _to_kRate_SetValueCurve(values, startTime, duration, onended) {
-    var valuesLength = values.length,
-      coeff = valuesLength / duration,
-      Ts = 1 / this.context.sampleRate,
-      i, val
-
-    this._dsp = function(array) {
-      val = values[Math.min(Math.round(coeff * (this.context.currentTime - startTime)), valuesLength - 1)]
-      for (i = 0; i < BLOCK_SIZE; i++) array[i] = val
-      this._instrinsicValue = array[BLOCK_SIZE - 1]
-    }
-  }
-
-  _geometricSeries(U0, ratio) {
-    var Un = U0
-    return function() {
-      return Un *= ratio
-    }
-  }
-
-  _arithmeticSeries(U0, step) {
-    var Un = U0
-    return function() {
-      return Un += step
-    }
+    this._instrinsicValue = array[BLOCK_SIZE - 1]
   }
 
   cancelScheduledValues(startTime) {

--- a/test/AudioParam-test.js
+++ b/test/AudioParam-test.js
@@ -8,8 +8,7 @@ const helpers = initHelpers()
 let {
   assertAllValuesEqual,
   assertAllValuesApprox,
-  assertAllValuesFunc,
-  assertApproxEqual
+  assertAllValuesFunc
 } = helpers
 
 const SAMPLE_RATE = 44100
@@ -62,14 +61,6 @@ describe('AudioParam', function() {
     })
   })
 
-  it('should remove all events when the value is set', function() {
-    var audioParam = new AudioParam(dummyContext, 98)
-    audioParam._schedule('bla', 9)
-    assert.equal(audioParam._scheduled.length, 1)
-    audioParam.value = 99
-    assert.equal(audioParam._scheduled.length, 0)
-  })
-
   it('should be initialized with constant dsp method', function() {
     var audioParam = new AudioParam(dummyContext, 44)
       , block
@@ -81,30 +72,6 @@ describe('AudioParam', function() {
     block = audioParam._tick()
     assertValidBlock(block)
     assertAllValuesEqual(block.getChannelData(0), 44)
-  })
-
-  describe('_geometricSeries', function() {
-
-    it('should progress as expected', function() {
-      var audioParam = new AudioParam(dummyContext, 6)
-        , iter = audioParam._geometricSeries(1, 2)
-      assert.equal(iter(), 2)
-      assert.equal(iter(), 4)
-      assert.equal(iter(), 8)
-    })
-
-  })
-
-  describe('_arithmeticSeries', function() {
-
-    it('should progress as expected', function() {
-      var audioParam = new AudioParam(dummyContext, 6)
-        , iter = audioParam._arithmeticSeries(1, 2)
-      assert.equal(iter(), 3)
-      assert.equal(iter(), 5)
-      assert.equal(iter(), 7)
-    })
-
   })
 
   describe('value', function() {
@@ -167,11 +134,9 @@ describe('AudioParam', function() {
       })
 
       // Ramp finished, back to constant
-      assert.equal(audioParam._scheduled.length, 1)
       block = audioParam._tick()
       assertValidBlock(block)
       assertAllValuesEqual(block.getChannelData(0), 25)
-      assert.equal(audioParam._scheduled.length, 0)
       assert.equal(audioParam.value, 25)
 
       // Ramp t=1 -> t=3 // 25 -> 20
@@ -183,11 +148,9 @@ describe('AudioParam', function() {
       })
 
       // Ramp finished, back to constant
-      assert.equal(audioParam._scheduled.length, 1)
       block = audioParam._tick()
       assertValidBlock(block)
       assertAllValuesEqual(block.getChannelData(0), 20)
-      assert.equal(audioParam._scheduled.length, 0)
       assert.equal(audioParam.value, 20)
     })
 
@@ -204,11 +167,9 @@ describe('AudioParam', function() {
       })
 
       // Ramp finished, back to constant
-      assert.equal(audioParam._scheduled.length, 1)
       block = audioParam._tick()
       assertValidBlock(block)
       assertAllValuesEqual(block.getChannelData(0), 25)
-      assert.equal(audioParam._scheduled.length, 0)
       assert.equal(audioParam.value, 25)
 
       // Ramp t=1 -> t=3 // 25 -> 20
@@ -220,11 +181,9 @@ describe('AudioParam', function() {
       })
 
       // Ramp finished, back to constant
-      assert.equal(audioParam._scheduled.length, 1)
       block = audioParam._tick()
       assertValidBlock(block)
       assertAllValuesEqual(block.getChannelData(0), 20)
-      assert.equal(audioParam._scheduled.length, 0)
       assert.equal(audioParam.value, 20)
     })
 
@@ -261,16 +220,14 @@ describe('AudioParam', function() {
       })
 
       // Ramp finished, back to constant
-      assert.equal(audioParam._scheduled.length, 1)
       block = audioParam._tick()
       assertValidBlock(block)
       assertAllValuesEqual(block.getChannelData(0), 2)
-      assert.equal(audioParam._scheduled.length, 0)
       assert.equal(audioParam.value, 2)
 
       // Ramp t=1 -> t=3 // 10 -> 5
-      audioParam.value = 10
       dummyContext.currentTime = 1
+      audioParam.value = 10
       audioParam.exponentialRampToValueAtTime(5, 3)
       untilTime(audioParam, 3, function(block, Tb) {
         assertValidBlock(block)
@@ -278,11 +235,9 @@ describe('AudioParam', function() {
       })
 
       // Ramp finished, back to constant
-      assert.equal(audioParam._scheduled.length, 1)
       block = audioParam._tick()
       assertValidBlock(block)
       assertAllValuesEqual(block.getChannelData(0), 5)
-      assert.equal(audioParam._scheduled.length, 0)
       assert.equal(audioParam.value, 5)
     })
 
@@ -299,16 +254,14 @@ describe('AudioParam', function() {
       })
 
       // Ramp finished, back to constant
-      assert.equal(audioParam._scheduled.length, 1)
       block = audioParam._tick()
       assertValidBlock(block)
       assertAllValuesEqual(block.getChannelData(0), 2)
-      assert.equal(audioParam._scheduled.length, 0)
       assert.equal(audioParam.value, 2)
 
       // Ramp t=1 -> t=3 // 10 -> 5
-      audioParam.value = 10
       dummyContext.currentTime = 1
+      audioParam.value = 10
       audioParam.exponentialRampToValueAtTime(5, 3)
       untilTime(audioParam, 3, function(block, Tb) {
         assertValidBlock(block)
@@ -316,11 +269,9 @@ describe('AudioParam', function() {
       })
 
       // Ramp finished, back to constant
-      assert.equal(audioParam._scheduled.length, 1)
       block = audioParam._tick()
       assertValidBlock(block)
       assertAllValuesEqual(block.getChannelData(0), 5)
-      assert.equal(audioParam._scheduled.length, 0)
       assert.equal(audioParam.value, 5)
     })
 
@@ -348,7 +299,6 @@ describe('AudioParam', function() {
       block = audioParam._tick()
       assertValidBlock(block)
       assertAllValuesEqual(block.getChannelData(0), 2)
-      assert.equal(audioParam._scheduled.length, 0)
       assert.equal(audioParam.value, 2)
 
       // Ramp t=2 -> ... // 10 -> 5
@@ -380,7 +330,6 @@ describe('AudioParam', function() {
       block = audioParam._tick()
       assertValidBlock(block)
       assertAllValuesEqual(block.getChannelData(0), 2)
-      assert.equal(audioParam._scheduled.length, 0)
       assert.equal(audioParam.value, 2)
 
       // Ramp t=2 -> ... // 10 -> 5
@@ -400,11 +349,8 @@ describe('AudioParam', function() {
 
     it('should calculate the values for each sample if a-rate', function() {
       var audioParam = new AudioParam(dummyContext, 1, 'a')
-        , t1 = 12800 / 10 * Ts
-        , t2 = t1 + 12800 / 5 * Ts
-        , t3 = t2 + 12800 / 5 * Ts
-        , t4 = t3 + 12800 / 5 * Ts
-        , t5 = t4 + (12800 / 10 + 12800 / 5) * Ts
+        , t1 = 12800 * Ts
+        , t2 = t1 + (12800 / 10) * Ts
         , block
 
       // Ramp t=0
@@ -412,21 +358,9 @@ describe('AudioParam', function() {
       assert.equal(audioParam.value, 1)
       untilTime(audioParam, t1, function(block, Tb) {
         assertValidBlock(block)
-        assertAllValuesEqual(block.getChannelData(0), 1)
+        assertAllValuesFunc(block.getChannelData(0), Tb, function(t) { return Math.min(1 + 4 * t / (12800 * Ts), 5) })
       })
-      untilTime(audioParam, t2, function(block, Tb) {
-        assertValidBlock(block)
-        assertAllValuesEqual(block.getChannelData(0), 2)
-      })
-      untilTime(audioParam, t3, function(block, Tb) {
-        assertValidBlock(block)
-        assertAllValuesEqual(block.getChannelData(0), 3)
-      })
-      untilTime(audioParam, t4, function(block, Tb) {
-        assertValidBlock(block)
-        assertAllValuesEqual(block.getChannelData(0), 4)
-      })
-      untilTime(audioParam, t5, function(block, Tb) {
+      untilTime(audioParam, t2, function(block) {
         assertValidBlock(block)
         assertAllValuesEqual(block.getChannelData(0), 5)
       })
@@ -435,7 +369,6 @@ describe('AudioParam', function() {
       block = audioParam._tick()
       assertValidBlock(block)
       assertAllValuesEqual(block.getChannelData(0), 5)
-      assert.equal(audioParam._scheduled.length, 0)
       assert.equal(audioParam.value, 5)
     })
 
@@ -446,23 +379,11 @@ describe('AudioParam', function() {
       // Ramp t=0
       audioParam.setValueCurveAtTime([1, 2, 3, 4, 5], 0, 10000 * Ts)
       assert.equal(audioParam.value, 1)
-      untilTime(audioParam, 1000 * Ts, function(block, Tb) {
+      untilTime(audioParam, 10000 * Ts, function(block, Tb) {
         assertValidBlock(block)
-        assertAllValuesEqual(block.getChannelData(0), 1)
+        assertAllValuesApprox(block.getChannelData(0), Math.min(1 + 4 * Tb / (10000 * Ts), 5))
       })
-      untilTime(audioParam, 3000 * Ts, function(block, Tb) {
-        assertValidBlock(block)
-        assertAllValuesEqual(block.getChannelData(0), 2)
-      })
-      untilTime(audioParam, 5000 * Ts, function(block, Tb) {
-        assertValidBlock(block)
-        assertAllValuesEqual(block.getChannelData(0), 3)
-      })
-      untilTime(audioParam, 7000 * Ts, function(block, Tb) {
-        assertValidBlock(block)
-        assertAllValuesEqual(block.getChannelData(0), 4)
-      })
-      untilTime(audioParam, 1000 * Ts, function(block, Tb) {
+      untilTime(audioParam, 20000 * Ts, function(block, Tb) {
         assertValidBlock(block)
         assertAllValuesEqual(block.getChannelData(0), 5)
       })
@@ -471,7 +392,6 @@ describe('AudioParam', function() {
       block = audioParam._tick()
       assertValidBlock(block)
       assertAllValuesEqual(block.getChannelData(0), 5)
-      assert.equal(audioParam._scheduled.length, 0)
       assert.equal(audioParam.value, 5)
     })
 
@@ -491,11 +411,12 @@ describe('AudioParam', function() {
       // t=2 -> t=3 / 0 -> 1
 
       untilTime(audioParam, 2, function(block) {
+        var end = Math.min(128, Math.round((2 - audioParam.context.currentTime) * audioParam.context.sampleRate))
         assertValidBlock(block)
-        assertAllValuesEqual(block.getChannelData(0), -1)
+        assertAllValuesEqual(block.getChannelData(0).slice(0, end), -1)
       })
 
-      var T0 = audioParam.context.currentTime
+      var T0 = 2
       untilTime(audioParam, 3, function(block, Tb) {
         assertValidBlock(block)
         assertAllValuesFunc(block.getChannelData(0), Tb, function(t) { return Math.min((t - T0) / (3 - T0), 1) })


### PR DESCRIPTION
This PR replaces the internal processing of automation events by using the automation-events package. It's meant to fix #84.

I noticed that the current implementation of value curve automations applies the curve values in steps. This should be fixed now since automation-events interpolates between the values. 

I tried to follow the coding style as good as possible. Please let me know if there is anything I should update.

Once this is PR is merged we could very easily implement the methods for canceling scheduled events since they are already supported by automation-events.